### PR TITLE
#47-    대댓글 도메인 설계

### DIFF
--- a/board/src/main/java/com/example/board/domain/ArticleComment.java
+++ b/board/src/main/java/com/example/board/domain/ArticleComment.java
@@ -5,7 +5,9 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -30,19 +32,34 @@ public class ArticleComment extends AuditingFields {
     @ManyToOne(optional = false)
     private UserAccount userAccount; // 유저 정보 (ID)
 
+    @Setter
+    @Column(updatable = false)
+    private Long parentCommentId;
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
     @Setter @Column(nullable = false, length = 500) private String content; // 본문
 
 
     protected ArticleComment() {}
 
-    private ArticleComment(Article article, UserAccount userAccount, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null,content);
+    }
+
+    public void addChildComment(ArticleComment child){
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
대댓글 도메인 안에서 부모 자식 관계를 설정하는 코드를 추가 자식 댓글의 컬렉션 변화가 쿼리에 반영하겠끔  cascading규칙을 모두 적용 이번엔 단방향 연관관계 설정을 사용해보기로 함 따라서 부모 댓글은 엔티티가 아닌 logn id 를 직접 표현 또한 자식 댓글을 추가할 수 있는 메소드 추가 내용